### PR TITLE
send photo_url key in upload payload to match  backend name

### DIFF
--- a/src/dashboard/Dashboard.jsx
+++ b/src/dashboard/Dashboard.jsx
@@ -385,7 +385,7 @@ export default function Dashboard() {
       const photoUrl = await getDownloadURL(fileRef);
 
       const payload = {
-        photoUrl,
+        photo_url: photoUrl,
         storagePath,
         description: pendingDescription.trim() || 'New photo',
       };


### PR DESCRIPTION

The upload payload was sending "PhotoUrl" but the backend photoentity was expecting/using photo_url, so the URL was being saved as null on database. Photos would appear initially on upload but disappear if page was refreshed since the DB returned a null value. Renamed payload key to photo_url so the url is now correctly saved.